### PR TITLE
add : OutputPass in PostProcessRenderer

### DIFF
--- a/demoSrc/Common.js
+++ b/demoSrc/Common.js
@@ -14,8 +14,8 @@ export class Common {
     return scene;
   }
 
-  static initLight(scene) {
-    const ambientLight = new AmbientLight(0xffffff, Math.PI);
+  static initLight(scene, intensity = Math.PI) {
+    const ambientLight = new AmbientLight(0xffffff, intensity);
     scene.add(ambientLight);
     return ambientLight;
   }

--- a/demoSrc/demoBloom.js
+++ b/demoSrc/demoBloom.js
@@ -16,7 +16,6 @@ import {
 } from "../esm/index.js";
 import GUI from "lil-gui";
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
-import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
 import { RAFTicker } from "@masatomakino/raf-ticker";
 
 export class StudyBloom {
@@ -25,7 +24,7 @@ export class StudyBloom {
     const H = 480;
 
     const scene = Common.initScene();
-    Common.initLight(scene, 1.6);
+    Common.initLight(scene);
     const camera = Common.initCamera(scene, W, H);
     const renderer = Common.initRenderer(W, H);
     const control = Common.initControl(camera, renderer);
@@ -45,7 +44,7 @@ export class StudyBloom {
     const mixPass = new MixShaderPass(this.bloom.result);
 
     this.postRenderer.composers.push(this.bloom);
-    this.postRenderer.addComposer([mixPass, new OutputPass()], renderPass);
+    this.postRenderer.addComposer([mixPass], renderPass);
     RAFTicker.on("tick", this.postRenderer.render);
 
     this.initGUI();

--- a/src/mix/MixShader.frag.glsl.ts
+++ b/src/mix/MixShader.frag.glsl.ts
@@ -1,6 +1,6 @@
 export default () => {
   //language=GLSL
-  return `    
+  return /* GLSL */ `    
 uniform sampler2D tDiffuse;
 uniform sampler2D mixTexture;
 varying vec2 vUv;
@@ -9,5 +9,6 @@ vec4 getTexture( sampler2D map ) {
 }
 void main() {
     gl_FragColor = ( getTexture( tDiffuse ) + vec4( 1.0 ) * getTexture( mixTexture ) );
-}`;
+}
+`;
 };

--- a/src/postprocess/PostProcessRenderer.ts
+++ b/src/postprocess/PostProcessRenderer.ts
@@ -6,6 +6,7 @@ import {
   Camera,
 } from "three";
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
+import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
 import { Pass } from "three/examples/jsm/postprocessing/Pass.js";
 import { PostProcessEffectComposer } from "./PostProcessEffectComposer.js";
 import { RAFTickerEventContext } from "@masatomakino/raf-ticker";
@@ -66,10 +67,18 @@ export class PostProcessRenderer {
   ): PostProcessEffectComposer {
     RenderPassOption.init(renderPassOption);
     const composer = new PostProcessEffectComposer(renderer);
+
+    //先頭にレンダーパスを挿入
     composer.addPass(renderPassOption.renderPass);
+
+    //中間にエフェクトパスを挿入
     passes.forEach((p) => {
       composer.addPass(p);
     });
+
+    //末端にOutputPassを挿入
+    composer.addPass(new OutputPass());
+
     return composer;
   }
 


### PR DESCRIPTION
see : https://threejs.org/docs/#manual/en/introduction/How-to-use-post-processing

公式ドキュメントのポストプロセスワークフローにOutputPassという処理が追加されていた。

これを追加したところ、以前のカラーマネージメント状態に近い出力を得られた。