### PR TITLE
bump : three r168

### DIFF
--- a/__test__/postprocess/BloomEffectComposer.spec.ts
+++ b/__test__/postprocess/BloomEffectComposer.spec.ts
@@ -1,12 +1,11 @@
-import { beforeEach, describe, expect, it, test, vi } from "vitest";
-import { renderingPass } from "./PassRender.js";
+import { describe, expect, it, vi } from "vitest";
 import {
   BloomEffectComposer,
   MixShaderPass,
   PostProcessRenderer,
 } from "../../src/index.js";
 import { generateScene } from "./SceneGenerator.js";
-import { RenderPass } from "three/examples/jsm/Addons.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { BoxGeometry, Mesh, MeshBasicMaterial, MeshPhongMaterial } from "three";
 
 describe("BloomEffectComposer", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@masatomakino/gulptask-demo-page": "^0.8.3",
-        "@types/three": "^0.167.1",
+        "@types/three": "^0.168.0",
         "@vitest/browser": "^2.0.5",
         "@vitest/coverage-istanbul": "^2.0.5",
         "browser-sync": "^3.0.2",
@@ -18,7 +18,7 @@
         "lil-gui": "^0.19.2",
         "lint-staged": "^15.2.10",
         "prettier": "^3.3.3",
-        "three": "^0.167.1",
+        "three": "^0.168.0",
         "typedoc": "^0.26.5",
         "typescript": "^5.5.4",
         "webdriverio": "^8.39.0"
@@ -2971,9 +2971,9 @@
       "dev": true
     },
     "node_modules/@tweenjs/tween.js": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.2.tgz",
-      "integrity": "sha512-kMCNaZCJugWI86xiEHaY338CU5JpD0B97p1j1IKNn/Zto8PgACjQx0UxbHjmOcLl/dDOBnItwD07KmCs75pxtQ==",
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "dev": true
     },
     "node_modules/@types/aria-query": {
@@ -3046,14 +3046,15 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.167.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.167.1.tgz",
-      "integrity": "sha512-OCd2Uv/8/4TbmSaIRFawrCOnDMLdpaa+QGJdhlUBmdfbHjLY8k6uFc0tde2/UvcaHQ6NtLl28onj/vJfofV+Tg==",
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-qAGLGzbaYgkkonOBfwOr+TZpOskPfFjrDAj801WQSVkUz0/D9zwir4vhruJ/CC/GteywzR9pqeVVfs5th/2oKw==",
       "dev": true,
       "dependencies": {
-        "@tweenjs/tween.js": "~23.1.2",
+        "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": "*",
+        "@webgpu/types": "*",
         "fflate": "~0.8.2",
         "meshoptimizer": "~0.18.1"
       }
@@ -3509,6 +3510,12 @@
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.44.tgz",
+      "integrity": "sha512-JDpYJN5E/asw84LTYhKyvPpxGnD+bAKPtpW9Ilurf7cZpxaTbxkQcGwOd7jgB9BPBrTYQ+32ufo4HiuomTjHNQ==",
+      "dev": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -10824,9 +10831,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.167.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
-      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw==",
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==",
       "dev": true
     },
     "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@masatomakino/gulptask-demo-page": "^0.8.3",
-    "@types/three": "^0.167.1",
+    "@types/three": "^0.168.0",
     "@vitest/browser": "^2.0.5",
     "@vitest/coverage-istanbul": "^2.0.5",
     "browser-sync": "^3.0.2",
@@ -30,7 +30,7 @@
     "lil-gui": "^0.19.2",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
-    "three": "^0.167.1",
+    "three": "^0.168.0",
     "typedoc": "^0.26.5",
     "typescript": "^5.5.4",
     "webdriverio": "^8.39.0"


### PR DESCRIPTION
"three/examples/jsm/Addons.js"の内部にNodeMaterialへの参照が含まれているためテストに失敗していた。